### PR TITLE
Added alacritty terminal colorscheme.

### DIFF
--- a/extras/alacritty_aurora.yml
+++ b/extras/alacritty_aurora.yml
@@ -1,0 +1,30 @@
+schemes:
+  aurora: &aurora
+    primary:
+      background: "#211c2f"
+      foreground: "#daeeeb"
+
+    selection:
+      text: "#141425"
+
+    normal:
+      black: "#5f5f87"
+      red: "#d93234"
+      green: "#9ec410"
+      yellow: "#ffbe00"
+      blue: "#2782d4"
+      magenta: "#b77ee0"
+      cyan: "#54ced6"
+      white: "#ececec"
+
+    bright:
+      black: "#5f5f87"
+      red: "#d93234"
+      green: "#9ec410"
+      yellow: "#ffbe00"
+      blue: "#2782d4"
+      magenta: "#b77ee0"
+      cyan: "#54ced6"
+      white: "#ececec"
+
+colors: *aurora


### PR DESCRIPTION
Love the colorscheme :heart: I usually dislike having my terminal colorscheme clash with my nvim colorscheme, so I made a very basic colorscheme for my terminal emulator of choice, alacritty. If you want me to update it or think some other colors may appear better, let me know.
![cli_aurora](https://user-images.githubusercontent.com/93833532/141604429-b69fd8c8-ca09-4956-ad11-820f6db4c47b.png)
![htop_aurora](https://user-images.githubusercontent.com/93833532/141604432-170baf84-ca1c-48aa-9c31-c364bbe0ad8c.png)
![nvim_and_alacritty](https://user-images.githubusercontent.com/93833532/141604507-551575ee-9ca1-4698-ad35-edf882b8c5b6.png)
