### PR TITLE
fix gvim background always light

### DIFF
--- a/colors/aurora.vim
+++ b/colors/aurora.vim
@@ -55,6 +55,7 @@ if has('nvim-0.8') == 1
   " packadd aurora
   lua require('aurora').colorscheme()
 else
+  execute 'hi Normal guifg=#dacfb4 ctermfg=187 guibg=' . bg . ' ctermbg=235 gui=NONE cterm=NONE'
   hi link SignifySignAdd GitGutterAdd
   hi link SignifySignDelete GitGutterDelete
   hi link SignifySignDeleteFirstLine SignifySignDelete


### PR DESCRIPTION
In gvim the Normal highlight group's guibg must be set explicitly; unlike terminal vim, gvim does not inherit the background color from the terminal emulator. Without a Normal definition in the non-nvim path the background defaulted to white.

Fixes https://github.com/ray-x/aurora/issues/20